### PR TITLE
Initialize TypeFaceEditText.kt with imeOptions.

### DIFF
--- a/app/src/main/java/app/simple/inure/decorations/typeface/TypeFaceEditText.kt
+++ b/app/src/main/java/app/simple/inure/decorations/typeface/TypeFaceEditText.kt
@@ -9,6 +9,7 @@ import android.graphics.Color
 import android.os.Build
 import android.util.AttributeSet
 import android.view.animation.DecelerateInterpolator
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.annotation.ColorInt
@@ -54,6 +55,7 @@ open class TypeFaceEditText : AppCompatEditText, ThemeChangedListener {
         if (isInEditMode.invert()) {
             typeface = TypeFace.getTypeFace(AppearancePreferences.getAppFont(), typedArray.getInt(R.styleable.TypeFaceTextView_appFontStyle, -1), context)
             colorMode = typedArray.getInt(R.styleable.TypeFaceTextView_textColorStyle, 1)
+            imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
             setHighlightColor()
             setTextColor(colorMode, false)
             setHintTextColor(ThemeManager.theme.textViewTheme.tertiaryTextColor)


### PR DESCRIPTION
Add IME_FLAG_NO_EXTRACT_UI option to avoid the extra window getting created in landscape mode for editTexts for consistent behaviour for both Portrait and Landscape mode.