### PR TITLE
fix(webview): disable allowFileAccess in CustomWebView and WebViewXMLViewer

### DIFF
--- a/app/src/main/java/app/simple/inure/decorations/views/CustomWebView.kt
+++ b/app/src/main/java/app/simple/inure/decorations/views/CustomWebView.kt
@@ -27,7 +27,11 @@ open class CustomWebView(context: Context, attributeSet: AttributeSet) : WebView
 
     init {
         settings.allowContentAccess = true
-        settings.allowFileAccess = true
+        // CustomWebView is consumed by HTML.kt, which calls loadData(...)
+        // with base64-encoded HTML. There is no file:// load path through
+        // this WebView, and loads of file:///android_asset/* would remain
+        // available regardless of this flag.
+        settings.allowFileAccess = false
         settings.setSupportZoom(true)
         settings.javaScriptEnabled = true
         webChromeClient = WebChromeClient()

--- a/app/src/main/java/app/simple/inure/decorations/views/WebViewXMLViewer.kt
+++ b/app/src/main/java/app/simple/inure/decorations/views/WebViewXMLViewer.kt
@@ -26,7 +26,13 @@ class WebViewXMLViewer(context: Context, attributeSet: AttributeSet) : WebView(c
             setSupportZoom(true)
             domStorageEnabled = true
             allowContentAccess = true
-            allowFileAccess = true
+            // Consumers load this WebView via loadDataWithBaseURL with a
+            // file:///android_asset/ base, or via loadUrl on a
+            // file:///android_asset/ URL. Both paths work even when
+            // setAllowFileAccess is false, since android_asset is always
+            // permitted. shouldInterceptRequest above also serves
+            // android_asset URLs from the AssetManager directly.
+            allowFileAccess = false
             javaScriptEnabled = true
             defaultTextEncodingName = "UTF-8"
             builtInZoomControls = true


### PR DESCRIPTION
Closes #482.

Both `CustomWebView` and `WebViewXMLViewer` set `settings.allowFileAccess = true` even though neither one actually relies on the flag for its real load paths.

### CustomWebView

Only consumer is `HTML.kt`, which calls `html.loadData(encodedHtml, MimeConstants.htmlType, "base64")`. No `file://` URL passes through this WebView, so the flag adds attack surface without enabling any feature. With `javaScriptEnabled = true` and `loadUrl("javascript:...")` already present, the WebView is JS-active enough that keeping a redundant file flag on is just risk.

This PR flips it to `false` and explains the load-path assumption with a short inline comment.

### WebViewXMLViewer

Consumers are `HtmlViewer.kt` (`webView.loadUrl("file:///android_asset/html/required_permissions.html")`) and `XMLWebView.kt` (`manifest.loadDataWithBaseURL("file:///android_asset/", it, "text/html", "UTF-8", null)`). Both rely on the `file:///android_asset/` scheme, which is permitted on every supported Android version even when `setAllowFileAccess(false)` is in force. The `shouldInterceptRequest` override in this class also serves `android_asset` URLs directly from the `AssetManager`, which does not consult the flag.

This PR flips `allowFileAccess = false` here too, with a comment recording why the change is safe.