### PR TITLE
Catch ActivityNotFoundException in CustomWebView external link path

### DIFF
--- a/app/src/main/java/app/simple/inure/decorations/views/CustomWebView.kt
+++ b/app/src/main/java/app/simple/inure/decorations/views/CustomWebView.kt
@@ -1,9 +1,11 @@
 package app.simple.inure.decorations.views
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import android.util.AttributeSet
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -96,7 +98,11 @@ open class CustomWebView(context: Context, attributeSet: AttributeSet) : WebView
                     view.loadUrl(url)
                 } else {
                     val intent = Intent(Intent.ACTION_VIEW, request.url)
-                    context.startActivity(intent)
+                    try {
+                        context.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        Log.w(TAG, "No app installed to handle ${request.url}", e)
+                    }
                 }
                 return true
             }


### PR DESCRIPTION
Closes #484.

`CustomWebView.shouldOverrideUrlLoading` calls `context.startActivity(intent)` directly when a tapped URL is not an `asset/` link. If no installed app can handle `Intent.ACTION_VIEW` for the URL, `startActivity` raises `ActivityNotFoundException` and the host activity crashes (Changelog / Credits / Trackers / preference web pages, etc.). This shows up most often with `mailto:` links on devices with no mail app and external links on ROMs with the default browser disabled.

This wraps the call in a try / catch for `ActivityNotFoundException` and logs a warning. The click becomes a silent no-op, which is the usual outcome when there is no handler.

```diff
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
@@
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                 val url = request.url.toString()
                 if (url.contains("asset/")) {
                     view.loadUrl(url)
                 } else {
                     val intent = Intent(Intent.ACTION_VIEW, request.url)
-                    context.startActivity(intent)
+                    try {
+                        context.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        Log.w(TAG, "No app installed to handle ${request.url}", e)
+                    }
                 }
                 return true
             }
```

`TAG` was already declared in the file's `companion object`.